### PR TITLE
Improve performance

### DIFF
--- a/Sources/LegoArtFilter/LegoArt.swift
+++ b/Sources/LegoArtFilter/LegoArt.swift
@@ -91,12 +91,19 @@ public class LegoArt {
               let rgbaData = resizedImage.rgbaData(baseColor: baseColor)
         else { return ([], 0) }
         let size = resizedImage.extent.size
+        var memo: [[UInt8]: LegoColor] = [:]
         let colorMap = (0 ..< Int(size.width * size.height))
             .map { i -> LegoColor in
-                let r = CGFloat(rgbaData[4 * i]) / 255.0
-                let g = CGFloat(rgbaData[4 * i + 1]) / 255.0
-                let b = CGFloat(rgbaData[4 * i + 2]) / 255.0
-                return LegoColor(r: r, g: g, b: b)
+                let rgb = [rgbaData[4 * i], rgbaData[4 * i + 1], rgbaData[4 * i + 2]]
+                if let legoColor = memo[rgb] {
+                    return legoColor
+                }
+                let r = CGFloat(rgb[0]) / 255.0
+                let g = CGFloat(rgb[1]) / 255.0
+                let b = CGFloat(rgb[2]) / 255.0
+                let legoColor = LegoColor(r: r, g: g, b: b)
+                memo[rgb] = legoColor
+                return legoColor
             }
         return (colorMap, Int(size.width))
     }


### PR DESCRIPTION
## 概要

`LegoColor(r:g:b:)` の処理に時間がかかるため、rgb の値をキーとしてキャッシュするようにしました。

私のアイコンを `StudType: Round` ・ `Max Stud: 128` で試したところ、処理時間が約 1/33 になりました。
同じ色を使っている画像ほど処理が速くなります。
逆にほぼ異なる色だと、キャッシュを捜査する分だけ処理が遅くなりますが、具体的な時間は計測していません。

処理時間の計測は `colorMap` 生成の前後に以下を仕込んで行いました。

```diff
+       let startDate = Date()
        let colorMap = (0 ..< Int(size.width * size.height))
            .map { i -> LegoColor in
                let r = CGFloat(rgbaData[4 * i]) / 255.0
                let g = CGFloat(rgbaData[4 * i + 1]) / 255.0
                let b = CGFloat(rgbaData[4 * i + 2]) / 255.0
                return LegoColor(r: r, g: g, b: b)
            }
+       print("Time: \(Date().timeIntervalSince(startDate))")
```

__Before__

|Time|
|:--|
|2.201616048812866|
|2.205173969268799|
|2.2091729640960693|
|2.2038110494613647|
|2.204527974128723|

__After__

|time|
|:--|
|0.06664800643920898|
|0.06678497791290283|
|0.06787693500518799|
|0.06665492057800293|
|0.06649196147918701|

<img width="690" alt="スクリーンショット 2021-10-18 20 35 40" src="https://user-images.githubusercontent.com/21194714/137723166-7af5324f-f748-4892-ab58-b8de2a815bde.png">